### PR TITLE
Make both memcache backends understand unix:// domain-socket paths

### DIFF
--- a/classes/MemcachedCache.php
+++ b/classes/MemcachedCache.php
@@ -28,7 +28,10 @@ class MemcachedCache extends AbstractCache
 		global $memcacheServer, $memcachePort;
 
 		$this->mc = new Memcached();
-		$this->mc->addServer($memcacheServer, $memcachePort);
+		if(substr($memcacheServer, 0, 7) == "unix://")
+			$this->mc->addServer(substr($memcacheServer, 7), 0);
+		else
+			$this->mc->addServer($memcacheServer, $memcachePort);
 	}
 
 	public function get($key)


### PR DESCRIPTION
Using a domain socket works diffrent for the two memcache librarys.
memcache expects the server to be in the format unix:///var/run/memcached/memcached.sock and a port of 0.
memcached just expects /var/run/memcached/memcached.sock and a port of 0.
