### PR TITLE
Add cli cron system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 /composer.lock
 *.sublime*
 .lighttpd.conf
+cron.overrides

--- a/cli.php
+++ b/cli.php
@@ -20,6 +20,12 @@
 $cle = "cli" == php_sapi_name();
 if (!$cle) return; // Prevent web execution
 
+if(getenv("SILENT_CLI"))
+{
+    ob_start("obCallback");
+    ob_implicit_flush();
+}
+
 $base = dirname(__FILE__);
 
 require_once "$base/init.php";
@@ -85,4 +91,10 @@ function listCommands()
 	}
 	sort($commands);
 	CLI::out(implode(" ", $commands), true);
+}
+
+function obCallback($buf)
+{
+    // Maybe log it somewhere, but for now just throw it away.
+    return "";
 }

--- a/cli/cli_apiFetch.php
+++ b/cli/cli_apiFetch.php
@@ -28,6 +28,13 @@ class cli_apiFetch implements cliCommand
 		return ""; // Space seperated list
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			60 => ""
+		);
+	}
+
 	public function execute($parameters)
 	{
 		Api::fetchApis();

--- a/cli/cli_calculateAllTimeStatsAndRanks.php
+++ b/cli/cli_calculateAllTimeStatsAndRanks.php
@@ -28,6 +28,13 @@ class cli_calculateAllTimeStatsAndRanks implements cliCommand
 		return "all ranks stats"; // Space seperated list
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			86400 => "ranks"
+		);
+	}
+
 	public function execute($parameters)
 	{
 		if (sizeof($parameters) == 0 || $parameters[0] == "") CLI::out("Usage: |g|recentStatsAndRanks <type>|n| To see a list of commands, use: |g|methods calculateAllTimeStatsAndRanks", true);
@@ -43,7 +50,7 @@ class cli_calculateAllTimeStatsAndRanks implements cliCommand
 			case "ranks":
 				self::ranks();
 			break;
-			
+
 			case "stats":
 				self::stats();
 			break;

--- a/cli/cli_calculateRecentStatsAndRanks.php
+++ b/cli/cli_calculateRecentStatsAndRanks.php
@@ -28,6 +28,13 @@ class cli_calculateRecentStatsAndRanks implements cliCommand
 		return "ranks stats all"; // Space seperated list
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			86400 => "stats"
+		);
+	}
+
 	public function execute($parameters)
 	{
 		if (sizeof($parameters) == 0 || $parameters[0] == "") CLI::out("Usage: |g|recentStatsAndRanks <type>|n| To see a list of commands, use: |g|methods recentStatsAndRanks", true);
@@ -43,7 +50,7 @@ class cli_calculateRecentStatsAndRanks implements cliCommand
 			case "ranks":
 				self::ranks();
 			break;
-			
+
 			case "stats":
 				self::stats();
 			break;

--- a/cli/cli_feed.php
+++ b/cli/cli_feed.php
@@ -28,6 +28,13 @@ class cli_feed implements cliCommand
 		return "add remove list fetch"; // Space seperated list
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			3600 => "fetch"
+		);
+	}
+
 	public function execute($parameters)
 	{
 		if (sizeof($parameters) == 0 || $parameters[0] == "") CLI::out("Usage: |g|help <command>|n| To see a list of commands, use: |g|list", true);
@@ -120,7 +127,7 @@ class cli_feed implements cliCommand
 							$json = json_encode($kill);
 							$killID = $kill->killID;
 							$source = "zKB Feed Fetch";
-							
+
 							$insertCount += Db::execute("INSERT IGNORE INTO zz_killmails (killID, hash, source, kill_json) VALUES (:killID, :hash, :source, :kill_json)", array(":killID" => $killID, ":hash" => $hash, ":source" => $source, ":kill_json" => $json));
 							Db::execute("UPDATE zz_feeds SET lastFetchTime = :time WHERE url = :url", array(":time" => date("Y-m-d H:i:s"), ":url" => $url));
 						}

--- a/cli/cli_hourly.php
+++ b/cli/cli_hourly.php
@@ -28,6 +28,13 @@ class cli_hourly implements cliCommand
 		return "";
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			3600 => ""
+		);
+	}
+
 	public function execute($parameters)
 	{
 		self::apiPercentage();

--- a/cli/cli_itemUpdate.php
+++ b/cli/cli_itemUpdate.php
@@ -28,6 +28,13 @@ class cli_itemUpdate implements cliCommand
 		return ""; // Space seperated list
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			21600 => ""
+		);
+	}
+
 	public function execute($parameters)
 	{
 		//Db::execute("insert ignore into ccp_invTypes (typeID, typeName) select distinct shipTypeID, concat('TypeID ', shipTypeID) from zz_participants");

--- a/cli/cli_minutely.php
+++ b/cli/cli_minutely.php
@@ -28,6 +28,13 @@ class cli_minutely implements cliCommand
 		return "killsLastHour cloudFlareRegister cloudFlareDelete fileCacheClean all"; // Space seperated list
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			60 => "all"
+		);
+	}
+
 	public function execute($parameters)
 	{
 		global $base;

--- a/cli/cli_p120s.php
+++ b/cli/cli_p120s.php
@@ -28,6 +28,13 @@ class cli_p120s implements cliCommand
 		return ""; // Space seperated list
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			60 => ""
+		);
+	}
+
 	public function execute($parameters)
 	{
 		$api120 = Db::query("select * from zz_api_characters where errorCode in (120)", array(), 0);
@@ -55,7 +62,7 @@ class cli_p120s implements cliCommand
 						$beforeKillID = substr($msg, 0, $pos);
 						try {
 							$result = $pheal->KillLog(array('characterID' => $charID, "beforeKillID" => $beforeKillID));
-						} catch (Exception $ex) { 
+						} catch (Exception $ex) {
 							Api::handleApiException($keyID, $charID, $ex);
 							continue;
 						}

--- a/cli/cli_parseKills.php
+++ b/cli/cli_parseKills.php
@@ -28,6 +28,13 @@ class cli_parseKills implements cliCommand
 		return ""; // Space seperated list
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			60 => ""
+		);
+	}
+
 	public function execute($parameters)
 	{
 		CLI::out("|g|Parsing killmails");

--- a/cli/cli_populateAlliances.php
+++ b/cli/cli_populateAlliances.php
@@ -28,6 +28,13 @@ class cli_populateAlliances implements cliCommand
 		return "";
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			28800 => ""
+		);
+	}
+
 	public function execute($parameters)
 	{
 		self::populateAlliances();
@@ -82,6 +89,6 @@ class cli_populateAlliances implements cliCommand
 			Log::log("Unable to pull Alliance XML from API.  Will try again later.");
 			if ($exception != null) throw $exception;
 			throw new Exception("Unable to pull Alliance XML from API.  Will try again later");
-		}	
+		}
 	}
 }

--- a/cli/cli_priceUpdate.php
+++ b/cli/cli_priceUpdate.php
@@ -28,6 +28,13 @@ class cli_priceUpdate implements cliCommand
 		return ""; // Space seperated list
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			86400 => ""
+		);
+	}
+
 	public function execute($parameters)
 	{
 		Db::execute("truncate zz_prices");

--- a/cli/cli_stompReceive.php
+++ b/cli/cli_stompReceive.php
@@ -22,10 +22,17 @@ class cli_stompReceive implements cliCommand
 	{
 		return "Receives data from the STOMP server. |w|Beware, this is a persistent script. It's run and forget!.|n| Usage: |g|stompRecieve";
 	}
-	
+
 	public function getAvailMethods()
 	{
 		return ""; // Space seperated list
+	}
+
+	public function getCronInfo()
+	{
+		return array(
+			60 => ""
+		);
 	}
 
 	public function execute($parameters)

--- a/cli/cli_summary.php
+++ b/cli/cli_summary.php
@@ -28,6 +28,13 @@ class cli_summary implements cliCommand
 		return ""; // Space seperated list
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			3600 => ""
+		);
+	}
+
 	public function execute($parameters)
 	{
 		$lastActualKills = Db::queryField("select contents count from zz_storage where locker = 'actualKills'", "count", array(), 0);

--- a/cli/cli_updateCharacters.php
+++ b/cli/cli_updateCharacters.php
@@ -28,6 +28,13 @@ class cli_updateCharacters implements cliCommand
 		return "";
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			60 => ""
+		);
+	}
+
 	public function execute($parameters)
 	{
 		self::updateCharacters();

--- a/cli/cli_updateCorporations.php
+++ b/cli/cli_updateCorporations.php
@@ -28,6 +28,13 @@ class cli_updateCorporations implements cliCommand
 		return "";
 	}
 
+	public function getCronInfo()
+	{
+		return array(
+			60 => ""
+		);
+	}
+
 	public function execute($parameters)
 	{
 				self::updateCorporations();

--- a/cliLock.sh
+++ b/cliLock.sh
@@ -14,7 +14,10 @@ locks=$base/cache/locks/
 mkdir -p $locks 2>/dev/null
 
 # Determine the lock file
-lockFile=$locks/$1.lock
+OIFS="$IFS"
+IFS="."
+lockFile="$locks/$*.lock"
+IFS="$OIFS"
 
 # Execute!
-flock -w 63 $lockFile php $base/cli.php $*
+flock -w 63 $lockFile php $base/cli.php "$@"

--- a/cron.php
+++ b/cron.php
@@ -1,0 +1,100 @@
+#!/usr/bin/env php
+<?php
+
+if(php_sapi_name() != "cli")
+    die("This is a cli script!");
+
+if(!extension_loaded('pcntl'))
+    die("This script needs the pcntl extension!");
+
+$base = __DIR__;
+require_once "$base/init.php";
+
+interface cliCommand {
+    public function getDescription();
+    public function getAvailMethods();
+    public function execute($parameters);
+}
+
+$curTime = time();
+$cronInfo = array();
+
+$files = scandir("$base/cli");
+foreach($files as $file)
+{
+    if(!preg_match("/^cli_(.+)\\.php$/", $file, $match))
+        continue;
+
+    $command = $match[1];
+    $className = "cli_$command";
+    require_once "$base/cli/$file";
+
+    if(!is_subclass_of($className, "cliCommand"))
+        continue;
+
+    if(!method_exists($className, "getCronInfo"))
+        continue;
+
+    $class = new $className();
+    $cronInfo[$command] = $class->getCronInfo();
+    unset($class);
+}
+
+if(file_exists("$base/cron.overrides"))
+{
+    $overrides = file_get_contents("$base/cron.overrides");
+    $overrides = json_decode($overrides, true);
+
+    foreach($overrides as $command => $info)
+        $cronInfo[$command] = $info;
+}
+
+foreach($cronInfo as $command => $info)
+{
+    foreach($info as $interval => $arguments)
+    {
+        runCron($command, $interval, $arguments);
+    }
+}
+
+function runCron($command, $interval, $args)
+{
+    global $base, $curTime;
+
+    if(is_array($args))
+        array_unshift($args, $command);
+    else if($args != "")
+        $args = explode(" ", "$command $args");
+    else
+        $args = array($command);
+
+    $cronName = implode(".", $args);
+    $locker = "lastCronRun.$cronName";
+    $lastRun = (int)Storage::retrieve($locker, 0);
+
+    $dateFormat = "D M j G:i:s T Y";
+    if($curTime - $lastRun < $interval)
+    {
+        echo "Cron $cronName last run at ".date($dateFormat, $lastRun)."\n";
+        return;
+    }
+
+    echo "Cron $cronName running at ".date($dateFormat, $curTime)."\n";
+
+    Storage::store($locker, $curTime);
+
+    $pid = pcntl_fork();
+    if($pid < 0)
+    {
+        Storage::store($locker, $lastRun);
+        return;
+    }
+
+    if($pid != 0)
+        return;
+
+    putenv("SILENT_CLI=1");
+    pcntl_exec("$base/cliLock.sh", $args);
+    Storage::store($locker, $lastRun);
+    die("Executing $command failed!");
+}


### PR DESCRIPTION
This adds a cli cron system.
Each cli_*.php script can now have an optional getCronInfo() method, which returns an array which describes how frequently(in seconds) to run this cli with which arguments. The arguments can either be a string or an array. If it's a string, the string is exploded on " " to get the indivudial arguments.

Additionaly, it parses $base/cron.overrides (which is a json formated file), and overrides all commands that are in there.
A possible cron.overrides file could be:

``` json
{
    "apiFetch": {
        "300":""
    },
    "parseKills": {
        "300":""
    },
    "stompReceive": {
    }
}
```

This would disable stompReceive entirely, and run apiFetch and parseKills every 5 minutes instead of every minute.

As the result, the only crontab that needs to be added now is running cron.php every minute.

The script needs the pcntl php extension, to fork of childs which continue to run in the background.
