### PR TITLE
Fix #1071 - Specified key was too long; max key length is 767 bytes

### DIFF
--- a/install/sql/zz_irc_access.sql
+++ b/install/sql/zz_irc_access.sql
@@ -3,7 +3,7 @@ DROP TABLE IF EXISTS `zz_irc_access`;
 CREATE TABLE `zz_irc_access` (
   `id` int(8) NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
-  `host` varchar(256) NOT NULL,
+  `host` varchar(255) NOT NULL,
   `accessLevel` int(8) NOT NULL DEFAULT '0',
   `insertTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),


### PR DESCRIPTION
This blocks installations on ubuntu 13 with mariadb 10
