### PR TITLE
Update readme apache2 instructions for latest version of apache2

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Apache rewrite is handled by the .htaccess, located in the /public directory.
 
         DocumentRoot /path/to/zkb_install/public/
         <Directory /path/to/zkb_install/public/>
+          Require all granted
           Options FollowSymLinks MultiViews
           AllowOverride All
           Order allow,deny


### PR DESCRIPTION
Supplied config is no longer sufficient for the latest versions of apache2.
